### PR TITLE
Wasm

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -170,55 +170,63 @@ class Versions:
 
 
 def get_semantic_version(qt_ver: str, is_preview: bool) -> Optional[Version]:
-    """Converts a Qt version string into a semantic version.
-    Handles both traditional format (e.g. '51212' -> '5.12.12') and
-    new format with underscores (e.g. '6_7_3' -> '6.7.3').
-
-    Args:
-        qt_ver: Version string (e.g. '51212', '600', '6_7_3')
-        is_preview: Whether this is a preview version
-
-    Returns:
-        Version object or None if invalid format
+    """Converts a Qt version string (596, 512, 5132, etc) into a semantic version.
+    This makes a lot of assumptions based on established patterns:
+    If is_preview is True, the number is interpreted as ver[0].ver[1:], with no patch.
+    If the version is 3 digits, then major, minor, and patch each get 1 digit.
+    If the version is 4 or more digits, then major gets 1 digit, minor gets 2 digits
+    and patch gets all the rest.
+    As of May 2021, the version strings at https://download.qt.io/online/qtsdkrepository
+    conform to this pattern; they are not guaranteed to do so in the future.
+    As of December 2024, it can handle version strings like 6_7_3 as well.
     """
     if not qt_ver:
         return None
 
-    try:
-        # Handle versions with underscores (new format)
-        if "_" in qt_ver:
-            parts = qt_ver.split("_")
-            if not (2 <= len(parts) <= 3):
-                return None
-
-            version_parts = [int(p) for p in parts]
-            major, minor = version_parts[:2]
-            patch = version_parts[2] if len(version_parts) > 2 else 0
-
-            version_str = f"{major}.{minor}.{patch}"
-            version_str += ".dev0" if is_preview else ""
-            return Version(version_str)
-
-        # Handle traditional format (continuous digits)
-        if not qt_ver.isdigit():
+    # Handle versions with underscores (new format)
+    if "_" in qt_ver:
+        parts = qt_ver.split("_")
+        if not (2 <= len(parts) <= 3):
             return None
 
-        # Parse version parts based on string length
-        if len(qt_ver) >= 4:
-            major, minor, patch = int(qt_ver[0]), int(qt_ver[1:3]), int(qt_ver[3:])
-        elif len(qt_ver) == 3:
-            major, minor, patch = int(qt_ver[0]), int(qt_ver[1]), int(qt_ver[2])
-        elif len(qt_ver) == 2:
-            major, minor, patch = int(qt_ver[0]), int(qt_ver[1]), 0
-        else:
-            return None
+        version_parts = [int(p) for p in parts]
+        major, minor = version_parts[:2]
+        patch = version_parts[2] if len(version_parts) > 2 else 0
 
-        version_str = f"{major}.{minor}.{patch}"
-        version_str += ".dev0" if is_preview else ""
-        return Version(version_str)
+        if is_preview:
+            minor_patch_combined = int(f"{minor}{patch}") if patch > 0 else minor
+            return Version(
+                major=major,
+                minor=minor_patch_combined,
+                patch=0,
+                prerelease=("preview",),
+            )
 
-    except ValueError:
+        return Version(
+            major=major,
+            minor=minor,
+            patch=patch,
+        )
+
+    # Handle traditional format (continuous digits)
+    if not qt_ver.isdigit():
         return None
+
+    if is_preview:
+        return Version(
+            major=int(qt_ver[0]),
+            minor=int(qt_ver[1:]),
+            patch=0,
+            prerelease=("preview",),
+        )
+    elif len(qt_ver) >= 4:
+        return Version(major=int(qt_ver[0]), minor=int(qt_ver[1:3]), patch=int(qt_ver[3:]))
+    elif len(qt_ver) == 3:
+        return Version(major=int(qt_ver[0]), minor=int(qt_ver[1]), patch=int(qt_ver[2]))
+    elif len(qt_ver) == 2:
+        return Version(major=int(qt_ver[0]), minor=int(qt_ver[1]), patch=0)
+
+    raise ValueError("Invalid version string '{}'".format(qt_ver))
 
 
 class ArchiveId:


### PR DESCRIPTION
`get_semantic_version` is now consistent with preview versions naming, and have the correct error raised with the correct error message
```python
# Before PR (current master branch version)
get_semantic_version('51212', False) -> '5.12.12'
get_semantic_version('600', False) -> '6.0.0'
get_semantic_version('6_7_3', False) -> None
get_semantic_version('51212', True) -> '5.1212-preview'
get_semantic_version('600', True) -> '6.0-preview'
get_semantic_version('6_7_3', True) -> None

# Before commit c4ce9f0
get_semantic_version('51212', False) -> '5.12.12'
get_semantic_version('600', False) -> '6.0.0'
get_semantic_version('6_7_3', False) -> '6.7.3'
get_semantic_version('51212', True) -> None
get_semantic_version('600', True) -> None
get_semantic_version('6_7_3', True) -> None

# Now
get_semantic_version('51212', False) -> '5.12.12'
get_semantic_version('600', False) -> '6.0.0'
get_semantic_version('6_7_3', False) -> '6.7.3'
get_semantic_version('51212', True) -> '5.1212-preview'
get_semantic_version('600', True) -> '6.0-preview'
get_semantic_version('6_7_3', True) -> '6.73-preview'
```